### PR TITLE
Fix compilation issue

### DIFF
--- a/feGEM_module.cxx
+++ b/feGEM_module.cxx
@@ -10,6 +10,7 @@
 #include "GEM_BANK_flow.h"
 
 #include "TTree.h"
+#include "TBranch.h"
 
 #include "manalyzer.h"
 #include "midasio.h"


### PR DESCRIPTION
IOFeatures.hxx:17:7: note: forward declaration of ‘class TBranch’

using root6.22.06 with gcc8.3