### PR TITLE
GNUMakefile doesn't define PROFILER preprocessor directive?

### DIFF
--- a/feGEMAnalyzer/feGEM_module.cxx
+++ b/feGEMAnalyzer/feGEM_module.cxx
@@ -266,7 +266,9 @@ public:
    feGEMModule(TARunInfo* runinfo, feGEMModuleFlags* flags)
       : TARunObject(runinfo), fFlags(flags)
    {
+#ifdef MANALYZER_PROFILER
       ModuleName="feGEM_module";
+#endif      
       writer = new feGEMModuleWriter();
       if (fTrace)
          printf("feGEMModule::ctor!\n");


### PR DESCRIPTION
Shall this applied also to https://github.com/josephmckenna/feGEM/commit/8479c1e864309a6699ecd6d8d86a7d610e1aec51/ ?